### PR TITLE
Need full path to ccx app; also added ccxcon

### DIFF
--- a/enable-ccx.md
+++ b/enable-ccx.md
@@ -17,7 +17,7 @@ FEATURES['CUSTOM_COURSES_EDX'] = True
 
 ##### Custom Courses for EdX #####
 if FEATURES.get('CUSTOM_COURSES_EDX'):
-        INSTALLED_APPS += ('ccx',)
+        INSTALLED_APPS += ('lms.djangoapps.ccx', 'openedx.core.djangoapps.ccxcon')
         FIELD_OVERRIDE_PROVIDERS += (
             'ccx.overrides.CustomCoursesForEdxOverrideProvider',
         )


### PR DESCRIPTION
The old approach was giving me an error

```
RuntimeError: Conflicting 'customcourseforedx' models in application 'ccx': <class 'lms.djangoapps.ccx.models.CustomCourseForEdX'> and <class 'ccx.models.CustomCourseForEdX'>.
```

I stole this approach from how it's configured in lms/envs/test.py

Begs the question why we don't just open a PR to edX to add CCX to devstack at this point.
