### PR TITLE
chore: update backend name of social auth

### DIFF
--- a/openedx/MITx-edx-integration-devstack.md
+++ b/openedx/MITx-edx-integration-devstack.md
@@ -43,21 +43,21 @@ to `edx.odl.local`. Your `/etc/hosts` entry should look like this::
 
 ## Setup social auth
 
-### Install `social-auth-mitxpro` in LMS
+### Install `ol-social-auth` in LMS
 
 There are two options for this:
 
 #### Install via pip
 
-    pip install social-auth-mitxpro
+    pip install ol-social-auth
 
 #### Install from local Build
 
-- Checkout the [social-auth-mitxpro](https://github.com/mitodl/social-auth-mitxpro) project and build the package per the project instructions
-- Copy the `social-auth-mitxpro-$VERSION.tar.gz` file into devstack's `edx-platform` directory
-- In devstack, run `make lms-shell` and within that shell `pip install social-auth-mitxpro-$VERSION.tar.gz`
+- Checkout the [ol-social-auth](https://github.com/mitodl/ol-social-auth) project and build the package per the project instructions
+- Copy the `ol-social-auth-$VERSION.tar.gz` file into devstack's `edx-platform` directory
+- In devstack, run `make lms-shell` and within that shell `pip install ol-social-auth-$VERSION.tar.gz`
 
-    - To update to a new development version without having to actually bump the package version, simply `pip uninstall social-auth-mitxpro`, then install again
+    - To update to a new development version without having to actually bump the package version, simply `pip uninstall ol-social-auth`, then install again
 
 ### Install `openedx-companion-auth` in LMS
 
@@ -93,6 +93,8 @@ To set up MIT Application:
    - `OPENEDX_API_BASE_URL`: set to `http://<EDX_HOSTNAME>:<PORT>`
    - `OPENEDX_SERVICE_WORKER_USERNAME`: set to `mit_Application_serviceworker` (unless you changed this)
    - `OPENEDX_SERVICE_WORKER_API_TOKEN`: set to the token you just generated
+   - `OPENEDX_OAUTH_PROVIDER`: set to `ol-oauth2`
+   - `OPENEDX_SOCIAL_LOGIN_PATH`: set to `/auth/login/ol-oauth2/?auth_entry=login`
 
    - Build the MIT Application: `docker-compose build`
 
@@ -119,21 +121,21 @@ In Open edX (derived from instructions [`here`](https://edx.readthedocs.io/proje
 
   REGISTRATION_EXTRA_FIELDS["country"] = "hidden"
 
-  THIRD_PARTY_AUTH_BACKENDS = ["social_auth_mitxpro.backends.MITxProOAuth2",]
+  THIRD_PARTY_AUTH_BACKENDS = ["ol_social_auth.backends.OLOAuth2",]
 
   AUTHENTICATION_BACKENDS = list(THIRD_PARTY_AUTH_BACKENDS) + list(AUTHENTICATION_BACKENDS)
 
   IDA_LOGOUT_URI_LIST = list(IDA_LOGOUT_URI_LIST) + list(["http://{Domain}:{PORT}/logout"])
 
   SOCIAL_AUTH_OAUTH_SECRETS = {
-    "mitxpro-oauth2": <mit_app_client_secret>  // you just copied from configure_instance command output
+    "ol-oauth2": <mit_app_client_secret>  // you just copied from configure_instance command output
   }
   ```
 
 - Login to django-admin (default username and password can be found [`here`](https://github.com/openedx/devstack#usernames-and-passwords)), go to `http://edx.odl.local:18000/admin/third_party_auth/oauth2providerconfig/`, and create a new config:
 
   - Select the default example site
-  - The slug field **MUST** match the the backend's name, which for us is `mitxpro-oauth2`
+  - The slug field **MUST** match the the backend's name, which for us is `ol-oauth2`
   - Check the following checkboxes:
 
     - Enabled
@@ -141,7 +143,7 @@ In Open edX (derived from instructions [`here`](https://edx.readthedocs.io/proje
     - Skip registration form
     - Sync learner profile data
     - Enable SSO id verification
-  - Set Backend name to: `mitxpro-oauth2`
+  - Set Backend name to: `ol-oauth2`
 
   - In "Other settings", put:
 

--- a/openedx/MITx-edx-integration-devstack.md
+++ b/openedx/MITx-edx-integration-devstack.md
@@ -53,7 +53,7 @@ There are two options for this:
 
 #### Install from local Build
 
-- Checkout the [ol-social-auth](https://github.com/mitodl/ol-social-auth) project and build the package per the project instructions
+- Checkout the [ol-social-auth](https://github.com/mitodl/open-edx-plugins/tree/main/src/ol_social_auth) project and build the package per the project instructions
 - Copy the `ol-social-auth-$VERSION.tar.gz` file into devstack's `edx-platform` directory
 - In devstack, run `make lms-shell` and within that shell `pip install ol-social-auth-$VERSION.tar.gz`
 

--- a/openedx/MITx-edx-integration-tutor.md
+++ b/openedx/MITx-edx-integration-tutor.md
@@ -64,6 +64,8 @@ To set up MIT Application:
    - `OPENEDX_API_BASE_URL`: set to `http://<EDX_HOSTNAME>:<PORT>`
    - `OPENEDX_SERVICE_WORKER_USERNAME`: set to `mit_Application_serviceworker` (unless you changed this)
    - `OPENEDX_SERVICE_WORKER_API_TOKEN`: set to the token you just generated
+   - `OPENEDX_OAUTH_PROVIDER`: set to `ol-oauth2`
+   - `OPENEDX_SOCIAL_LOGIN_PATH`: set to `/auth/login/ol-oauth2/?auth_entry=login`
 
 ### Run the configure_instance command
 
@@ -87,7 +89,7 @@ These steps will also disable the AuthN SSO MFE, so from here on you'll get norm
 3. Stop Tutor: `tutor dev stop`
 4. Add extra requirements required for OAuth Configuration:
 
-       tutor config save --append OPENEDX_EXTRA_PIP_REQUIREMENTS=social-auth-mitxpro
+       tutor config save --append OPENEDX_EXTRA_PIP_REQUIREMENTS=ol-social-auth
        tutor config save --append OPENEDX_EXTRA_PIP_REQUIREMENTS=openedx-companion-auth
 
    **NOTE**: Reference for [Installing extra xblocks and requirements](https://docs.tutor.edly.io/configuration.html#installing-extra-xblocks-and-requirements)
@@ -109,7 +111,7 @@ These steps will also disable the AuthN SSO MFE, so from here on you'll get norm
    IDA_LOGOUT_URI_LIST = list(IDA_LOGOUT_URI_LIST) + list(["http://{Domain}:{PORT}/logout"])
 
    SOCIAL_AUTH_OAUTH_SECRETS = {
-      "mitxpro-oauth2": <mit_app_client_secret>  // you just copied from configure_instance command output
+      "ol-oauth2": <mit_app_client_secret>  // you just copied from configure_instance command output
    }
    ```
 
@@ -132,7 +134,7 @@ These steps will also disable the AuthN SSO MFE, so from here on you'll get norm
       - `THIRD_PARTY_AUTH_BACKENDS = ['social_auth_mitxpro.backends.MITxProOAuth2']`
       - `REGISTRATION_EXTRA_FIELDS["country"] = "hidden"`
       - `AUTHENTICATION_BACKENDS.append('social_auth_mitxpro.backends.MITxProOAuth2')`
-      - `SOCIAL_AUTH_OAUTH_SECRETS = {"mitxpro-oauth2": <MIT_Client_Secret> }` - Client Secret that you just copied after `configure_instance` management command
+      - `SOCIAL_AUTH_OAUTH_SECRETS = {"ol-oauth2": <MIT_Client_Secret> }` - Client Secret that you just copied after `configure_instance` management command
       - `IDA_LOGOUT_URI_LIST.append('http://{Domain}:{PORT}/logout/')`
 
     - Find and update:
@@ -156,14 +158,14 @@ These steps will also disable the AuthN SSO MFE, so from here on you'll get norm
 
     - Enabled is **checked**.
     - Name: `Login with MIT App`
-    - Slug: `mitxpro-oauth2`
+    - Slug: `ol-oauth2`
     - Site: `local.openedx.io:8000`
     - Skip hinted login dialog is **checked**.
     - Skip registration form is **checked**.
     - Skip email verification is **checked**.
     - Sync learner profile data is **checked**.
     - Enable sso id verification is **checked**.
-    - Backend name: `mitxpro-oauth2`
+    - Backend name: `ol-oauth2`
     - `Client ID` and `Client Secret`: from record created by `configure_instance` when you set up MITx Application.
     - Other settings:
 

--- a/openedx/MITx-edx-integration-tutor.md
+++ b/openedx/MITx-edx-integration-tutor.md
@@ -104,7 +104,7 @@ These steps will also disable the AuthN SSO MFE, so from here on you'll get norm
 
    REGISTRATION_EXTRA_FIELDS["country"] = "hidden"
 
-   THIRD_PARTY_AUTH_BACKENDS = ["social_auth_mitxpro.backends.MITxProOAuth2",]
+   THIRD_PARTY_AUTH_BACKENDS = ["ol_social_auth.backends.OLOAuth2",]
 
    AUTHENTICATION_BACKENDS = list(THIRD_PARTY_AUTH_BACKENDS) + list(AUTHENTICATION_BACKENDS)
 
@@ -131,9 +131,9 @@ These steps will also disable the AuthN SSO MFE, so from here on you'll get norm
 
    - Add to the end of the file:
 
-      - `THIRD_PARTY_AUTH_BACKENDS = ['social_auth_mitxpro.backends.MITxProOAuth2']`
+      - `THIRD_PARTY_AUTH_BACKENDS = ['ol_social_auth.backends.OLOAuth2']`
       - `REGISTRATION_EXTRA_FIELDS["country"] = "hidden"`
-      - `AUTHENTICATION_BACKENDS.append('social_auth_mitxpro.backends.MITxProOAuth2')`
+      - `AUTHENTICATION_BACKENDS.append('ol_social_auth.backends.OLOAuth2')`
       - `SOCIAL_AUTH_OAUTH_SECRETS = {"ol-oauth2": <MIT_Client_Secret> }` - Client Secret that you just copied after `configure_instance` management command
       - `IDA_LOGOUT_URI_LIST.append('http://{Domain}:{PORT}/logout/')`
 


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/5726

### Description (What does it do?)
This PR changes the social auth backend name to new name in the integration docs

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
- Verify that the docs contain the new backend name and there's no old backend name left.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
