### PR TITLE
docs: add guide for edx-api-client package release

### DIFF
--- a/openedx/edx-api-client-release-process.md
+++ b/openedx/edx-api-client-release-process.md
@@ -10,17 +10,14 @@ This document describes the process for publishing a new release of the `edx-api
 
 1. **Go to Slack**
    - Open the `doof-edx-api-client` Slack channel.
-   - Send the message: `@doof release notes`
-   - This will cut a new release using the latest commits from the `master` branch.
+   - Cut a new release using `@doof release notes` and then selecting the appropriate version.
+   - This will cut a new release and create a PR using the latest commits from the `master` branch.
 
 2. **Test the Release**
-   - Ensure you have tested the changes locally.
-   - You can use the `release-candidate` branch to test the latest changes that will go to PyPI.
-   - After thorough testing, check the box in the new release on GitHub to confirm testing is complete.
+   - Test the release PR locally, and check all the boxes. (Never merge this PR manually)
 
 3. **Publish to PyPI**
-   - Go back to the Slack channel.
-   - Send the message: `@doof publish <new-version>`.
-   - This will publish the new release to PyPI automatically.
+   - Go back to the `doof-edx-api-client` Slack channel.
+   - Publish the new release to PyPI using `@doof publish <new-version>` (new-version is the version that you selected upon cutting a new release).
 
 ---

--- a/openedx/edx-api-client-release-process.md
+++ b/openedx/edx-api-client-release-process.md
@@ -1,0 +1,26 @@
+---
+parent: OpenedX
+---
+
+# edx-api-client Release Process
+
+This document describes the process for publishing a new release of the `edx-api-client` package to PyPI.
+
+## Steps to Publish a New Release
+
+1. **Go to Slack**
+   - Open the `doof-edx-api-client` Slack channel.
+   - Send the message: `@doof release notes`
+   - This will cut a new release using the latest commits from the `master` branch.
+
+2. **Test the Release**
+   - Ensure you have tested the changes locally.
+   - You can use the `release-candidate` branch to test the latest changes that will go to PyPI.
+   - After thorough testing, check the box in the new release on GitHub to confirm testing is complete.
+
+3. **Publish to PyPI**
+   - Go back to the Slack channel.
+   - Send the message: `@doof publish <new-version>`.
+   - This will publish the new release to PyPI automatically.
+
+---


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)

This PR adds a new markdown file, `edx-api-client-release-process.md`, documenting the release and publishing workflow for the edx-api-client package. The guide covers:

- How to cut a new release using the doof-edx-api-client Slack channel
- Steps for local testing and validation before publishing
- Instructions for publishing the new version to PyPI

This documentation aims to make the release process clear and repeatable for all contributors.
